### PR TITLE
various fixes

### DIFF
--- a/max-package/javascript/fluid.waveform~.js
+++ b/max-package/javascript/fluid.waveform~.js
@@ -484,11 +484,7 @@ function getHeight () {
 getHeight.local = 1; 
 
 function buffer (b) {
-  // Check if the buffer is a valid buffer
-  var bufferValid = new Buffer(b); 
-  if (bufferValid.framecount() != -1) {
-    addlayer('wave', b);
-  };
+  addlayer('wave',b);    
 }
 
 function markers () {
@@ -625,14 +621,12 @@ function ondrag (x, y, button, mod1, shift, caps, opt, mod2) {
 function onresize (x, y, button, mod1, shift, caps, opt, mod2) {
   width = box.rect[2] - box.rect[0];
   height = box.rect[3] - box.rect[1];
-  
-  render();
 
   if (disp) {
     disp.canvas.width = width;
-    disp.canvas.height = height;
-    redrawNeeded = true;
+    disp.canvas.height = height;     
   }
+  redrawNeeded = true;
 }
 
 function onidle (x, y, button, mod1, shift, caps, opt, mod2) {

--- a/max-package/javascript/fluid.waveform~.js
+++ b/max-package/javascript/fluid.waveform~.js
@@ -484,7 +484,11 @@ function getHeight () {
 getHeight.local = 1; 
 
 function buffer (b) {
-  addlayer('wave',b);    
+  // Check if the buffer is a valid buffer
+  var bufferValid = new Buffer(b); 
+  if (bufferValid.framecount() != -1) {
+    addlayer('wave', b);
+  };
 }
 
 function markers () {

--- a/max-package/javascript/fluid.waveform~.js
+++ b/max-package/javascript/fluid.waveform~.js
@@ -625,11 +625,13 @@ function ondrag (x, y, button, mod1, shift, caps, opt, mod2) {
 function onresize (x, y, button, mod1, shift, caps, opt, mod2) {
   width = box.rect[2] - box.rect[0];
   height = box.rect[3] - box.rect[1];
+  
+  render();
 
   if (disp) {
     disp.canvas.width = width;
     disp.canvas.height = height;
-    redrawNeeded = true; 
+    redrawNeeded = true;
   }
 }
 


### PR DESCRIPTION
This fixes two issues that were present in fluid.waveform~

1. If no `buffer` was passed to the waveform~ view then the background wouldn't draw because `disp === null`. I've made a cheap fix to this although its not great and might actually harm performance? I don't understand the code well enough.

2. I added a filter to check if an empty or bogus buffer has been passed to fluid.waveform~ which was causing also sorts of redness.
