### PR TITLE
flucoma/flucoma-max#368 hacky fix

### DIFF
--- a/max-package/jsui/fluid.waveform~.js
+++ b/max-package/jsui/fluid.waveform~.js
@@ -269,7 +269,7 @@ function getBuffer(name)
 function bufexists(name)
 {
     var b = getBuffer(name)
-    if (b.framecount() === -1 || b === null) return false
+    if (b === null || b.framecount() === -1) return false
     return true
 }
 
@@ -294,6 +294,18 @@ function badslicebuf(name)
 function err(msg)
 {
     error('fluid.waveform~: ' + msg + '\n')
+}
+
+function checkalllayers() {
+    alllayers.forEach(function (source)
+    {
+        if (!bufexists(source)) {
+            err('buffer' + ' "' + source + '" ' + 'no longer exists');
+            clear(); //calling clear does fix the buffer renaming bug but it's hacky
+            redrawNeeded = true;
+            return
+        }
+    })
 }
 
 function addlayer(type, source, r, g, b, a)
@@ -329,6 +341,7 @@ function addlayer(type, source, r, g, b, a)
     // discern if a new or existing layer
     if (index < 0)
     { // new
+        checkalllayers();
         var l = new LayerSpec();
         l.type = translatedType;
         l.source = source;

--- a/max-package/jsui/fluid.waveform~.js
+++ b/max-package/jsui/fluid.waveform~.js
@@ -464,6 +464,7 @@ function addmarkers(source, reference)
     const index = find(source);
     if (index < 0)
     {
+        checkalllayers();
         var l = new MarkersSpec(source, reference) //markerdata,fs,referenceLength)  
         l.type = 'markers';
         markerlayers.push(l);

--- a/max-package/jsui/fluid.waveform~.js
+++ b/max-package/jsui/fluid.waveform~.js
@@ -302,7 +302,6 @@ function checkalllayers() {
         if (!bufexists(source)) {
             err('buffer' + ' "' + source + '" ' + 'no longer exists');
             clear(); //calling clear does fix the buffer renaming bug but it's hacky
-            return
         }
     })
 }

--- a/max-package/jsui/fluid.waveform~.js
+++ b/max-package/jsui/fluid.waveform~.js
@@ -302,7 +302,6 @@ function checkalllayers() {
         if (!bufexists(source)) {
             err('buffer' + ' "' + source + '" ' + 'no longer exists');
             clear(); //calling clear does fix the buffer renaming bug but it's hacky
-            redrawNeeded = true;
             return
         }
     })


### PR DESCRIPTION
It does fix the issue, but it's also very brute force, as using `clear()` clears out everything in the object. A better solution might be to remove the specific layer that has disappeared and everything associated with it to try and preserve information in other layers. 

There may also be further edge cases where this bug may appear, but I have checked all the functions where I believe it might arise and called `checkalllayers()` from where necessary.

Currently the error messsage it spits out doesn't tell you which buffer disappeared, as the name of it is already gone by the time the check is done: `jsui: fluid.waveform~: buffer "[object Object]" no longer exists`. Might be worth implementing something to remember buffers so that the error is more useful to the user.

@jamesb93 