### PR TITLE
EOL `.gitattributes` normalisation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+* text=auto
+
+*.gitignore text
+*.js text
+*.json text
+*.maxhelp text
+*.md text
+*.txt text
+*.yaml text


### PR DESCRIPTION
EOL standardisation with .gitattributes to fix issues with versions of Git before 2.10 allowed automatic EOL conversion.